### PR TITLE
Add support for the new auth from Reaper v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,15 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ^1.15
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,20 +13,17 @@ jobs:
   build_and_test:
     name: Build and test reaper-client-go
     runs-on: ubuntu-latest
-    env:
-      GOPATH: /home/runner/go
-      GOROOT: /usr/local/go1.15
     steps:
       - name: Install docker-compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: Set up Go 1.x
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.15
-        id: go
+          go-version-file: 'go.mod'
+          cache: true
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
     name: Build and test reaper-client-go
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Install docker-compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -24,9 +27,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       - uses: actions/cache@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/k8ssandra/reaper-client-go
 
-go 1.15
+go 1.23.9
 
 require (
 	github.com/google/go-querystring v1.1.0
 	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/reaper/client.go
+++ b/reaper/client.go
@@ -2,6 +2,7 @@ package reaper
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -50,7 +51,7 @@ type Client interface {
 	UpdateRepairRun(ctx context.Context, repairRunId uuid.UUID, newIntensity Intensity) error
 
 	// StartRepairRun starts (or resumes) a repair run identified by its id. Can also be used to reattempt a repair run
-	// in state “ERROR”, picking up where it left off.
+	// in state "ERROR", picking up where it left off.
 	StartRepairRun(ctx context.Context, repairRunId uuid.UUID) error
 
 	// PauseRepairRun pauses a repair run identified by its id. The repair run must be in RUNNING state.
@@ -114,20 +115,28 @@ func (c *client) Login(ctx context.Context, username, password string) error {
 				c.jSessionId = &cookie.Value
 				return c.getJwt(ctx)
 			}
-			if cookie.Name == "jwtToken" {
-				c.jwt = &cookie.Value
+		}
+		// No JSESSIONID cookie found, check if response body contains JWT token in JSON format
+		respBody, readErr := c.readBodyAsString(resp)
+		if readErr == nil {
+			var loginResp struct {
+				Token    string   `json:"token"`
+				Username string   `json:"username"`
+				Roles    []string `json:"roles"`
+			}
+			if err := json.Unmarshal([]byte(respBody), &loginResp); err == nil && loginResp.Token != "" {
+				c.jwt = &loginResp.Token
 				return nil
 			}
 		}
-		respBody, _ := c.readBodyAsString(resp)
-		return fmt.Errorf("unable to log in. no JSESSIONID or jwtToken cookie. resp: %s - cookies: %v", respBody, cookies)
+		return fmt.Errorf("unable to log in. no JSESSIONID cookie and no JWT token in response body. resp: %s - cookies: %v", respBody, cookies)
 	} else {
 		return err
 	}
 }
 
 func (c *client) getJwt(ctx context.Context) error {
-	if resp, err := c.doGet(ctx, "/jwt", nil); err == nil {
+	if resp, err := c.doGet(ctx, "/jwt", nil, http.StatusOK); err == nil {
 		if jwt, err := c.readBodyAsString(resp); err == nil {
 			c.jwt = &jwt
 			c.jSessionId = nil

--- a/reaper/client.go
+++ b/reaper/client.go
@@ -114,9 +114,13 @@ func (c *client) Login(ctx context.Context, username, password string) error {
 				c.jSessionId = &cookie.Value
 				return c.getJwt(ctx)
 			}
+			if cookie.Name == "jwtToken" {
+				c.jwt = &cookie.Value
+				return nil
+			}
 		}
 		respBody, _ := c.readBodyAsString(resp)
-		return fmt.Errorf("unable to log in. no JSESSIONID cookie. resp: %s - cookies: %v", respBody, cookies)
+		return fmt.Errorf("unable to log in. no JSESSIONID or jwtToken cookie. resp: %s - cookies: %v", respBody, cookies)
 	} else {
 		return err
 	}


### PR DESCRIPTION
Reaper v4 now relies on a `jwtToken` cookie instead of a `JSESSIONID` one which could be used to get the jwt.